### PR TITLE
Keep component styles scoped

### DIFF
--- a/src/components/DashItem.vue
+++ b/src/components/DashItem.vue
@@ -481,7 +481,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .item {
   box-sizing: border-box;
   position: absolute;

--- a/src/components/DashLayout.vue
+++ b/src/components/DashLayout.vue
@@ -186,7 +186,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .placeholder {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
The un-scoped styles can create conflict in the application. Keeping these component styles encapsulated in the scope would eliminate this risk.